### PR TITLE
Update Python3 dockerfile and add setuptools

### DIFF
--- a/Python3/Dockerfile
+++ b/Python3/Dockerfile
@@ -1,6 +1,22 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.14-rc-alpine3.20
 
-RUN apk --no-cache add curl
-RUN apk add --no-cache git
+# Install system dependencies for building Python packages and image processing libraries for Pillow
+RUN apk add --no-cache \
+    build-base \
+    jpeg-dev \
+    zlib-dev \
+    libjpeg-turbo-dev \
+    libwebp-dev \
+    tiff-dev \
+    freetype-dev \
+    lcms2-dev \
+    openjpeg-dev \
+    tiff-dev \
+    musl-dev \
+    curl \
+    git
 
-CMD tail -f /dev/null
+# Install Python dependencies
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+CMD ["tail", "-f", "/dev/null"]
+


### PR DESCRIPTION
Update the base image to `python:3.14-rc-alpine3.20` and add setup and build tools for Pillow and other libraries. 